### PR TITLE
RightToLeft FlowDirection Support

### DIFF
--- a/BespokeFusion/MaterialMessageBox.cs
+++ b/BespokeFusion/MaterialMessageBox.cs
@@ -12,7 +12,8 @@ namespace BespokeFusion
         /// Displays a message box with OK button
         /// </summary>
         /// <param name="message">The message to display</param>
-        public static void Show(string message)
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
+        public static void Show(string message, bool IsRTL = false)
         {
             using (var msg = new MessageBoxWindow())
             {
@@ -22,7 +23,10 @@ namespace BespokeFusion
                 msg.TitleBackgroundPanel.Background = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                 msg.BorderBrush = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                 msg.BtnCancel.Visibility = Visibility.Collapsed;
-
+                if (IsRTL)
+                {
+                    msg.FlowDirection = FlowDirection.RightToLeft;
+                }
                 msg.BtnOk.Focus();
                 msg.ShowDialog();
             }
@@ -33,7 +37,8 @@ namespace BespokeFusion
         /// </summary>
         /// <param name="message">The message to display</param>
         /// <param name="title">The title of the message box</param>
-        public static void Show(string message, string title)
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
+        public static void Show(string message, string title, bool IsRTL = false)
         {
             using (var msg = new MessageBoxWindow())
             {
@@ -43,7 +48,10 @@ namespace BespokeFusion
                 msg.TitleBackgroundPanel.Background = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                 msg.BorderBrush = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                 msg.BtnCancel.Visibility = Visibility.Collapsed;
-
+                if (IsRTL)
+                {
+                    msg.FlowDirection = FlowDirection.RightToLeft;
+                }
                 msg.BtnOk.Focus();
                 msg.ShowDialog();
             }
@@ -53,7 +61,8 @@ namespace BespokeFusion
         /// Displays an error message box
         /// </summary>
         /// <param name="errorMessage">The error error message to display</param>
-        public static void ShowError(string errorMessage)
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
+        public static void ShowError(string errorMessage, bool IsRTL = false)
         {
             try
             {
@@ -65,7 +74,10 @@ namespace BespokeFusion
                     msg.TitleBackgroundPanel.Background = Brushes.Red;
                     msg.BorderBrush = Brushes.Red;
                     msg.BtnCancel.Visibility = Visibility.Collapsed;
-
+                    if (IsRTL)
+                    {
+                        msg.FlowDirection = FlowDirection.RightToLeft;
+                    }
                     msg.BtnOk.Focus();
                     msg.ShowDialog();
                 }
@@ -80,8 +92,9 @@ namespace BespokeFusion
         /// Displays a message box with a cancel button
         /// </summary>
         /// <param name="message">The message to display</param>
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
         /// <returns>Message box Result OK or CANCEL</returns>
-        public static MessageBoxResult ShowWithCancel(string message)
+        public static MessageBoxResult ShowWithCancel(string message, bool IsRTL = false)
         {
             try
             {
@@ -92,7 +105,10 @@ namespace BespokeFusion
                     msg.TxtMessage.Text = message;
                     msg.TitleBackgroundPanel.Background = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                     msg.BorderBrush = new SolidColorBrush(Color.FromRgb(3, 169, 244));
-
+                    if (IsRTL)
+                    {
+                        msg.FlowDirection = FlowDirection.RightToLeft;
+                    }
                     msg.BtnOk.Focus();
                     msg.ShowDialog();
                     return msg.Result == MessageBoxResult.OK ? MessageBoxResult.OK : MessageBoxResult.Cancel;
@@ -110,8 +126,9 @@ namespace BespokeFusion
         /// </summary>
         /// <param name="message">The message to display</param>
         /// <param name="title">The title of the message box</param>
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
         /// <returns>Message box Result OK or CANCEL</returns>
-        public static MessageBoxResult ShowWithCancel(string message, string title)
+        public static MessageBoxResult ShowWithCancel(string message, string title, bool IsRTL = false)
         {
             try
             {
@@ -122,7 +139,10 @@ namespace BespokeFusion
                     msg.TxtMessage.Text = message;
                     msg.TitleBackgroundPanel.Background = new SolidColorBrush(Color.FromRgb(3, 169, 244));
                     msg.BorderBrush = new SolidColorBrush(Color.FromRgb(3, 169, 244));
-
+                    if (IsRTL)
+                    {
+                        msg.FlowDirection = FlowDirection.RightToLeft;
+                    }
                     msg.BtnOk.Focus();
                     msg.ShowDialog();
                     return msg.Result == MessageBoxResult.OK ? MessageBoxResult.OK : MessageBoxResult.Cancel;
@@ -140,8 +160,9 @@ namespace BespokeFusion
         /// </summary>
         /// <param name="message">The message to display</param>
         /// <param name="isError">If the message is an error</param>
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
         /// <returns>Message box Result OK or CANCEL</returns>
-        public static MessageBoxResult ShowWithCancel(string message, bool isError)
+        public static MessageBoxResult ShowWithCancel(string message, bool isError, bool IsRTL = false)
         {
             try
             {
@@ -156,7 +177,10 @@ namespace BespokeFusion
                     msg.BorderBrush = isError 
                         ? Brushes.Red 
                         : new SolidColorBrush(Color.FromRgb(3, 169, 244));
-
+                    if (IsRTL)
+                    {
+                        msg.FlowDirection = FlowDirection.RightToLeft;
+                    }
                     msg.BtnOk.Focus();
                     msg.ShowDialog();
                     return msg.Result == MessageBoxResult.OK ? MessageBoxResult.OK : MessageBoxResult.Cancel;

--- a/BespokeFusion/MaterialMessageBox.cs
+++ b/BespokeFusion/MaterialMessageBox.cs
@@ -89,6 +89,38 @@ namespace BespokeFusion
         }
 
         /// <summary>
+        /// Displays an error message box
+        /// </summary>
+        /// <param name="errorMessage">The error error message to display</param>
+        /// <param name="title">The title of the message box</param>
+        /// <param name="IsRTL">(Optional) If true the MessageBox FlowDirection will be RightToLeft</param>
+        public static void ShowError(string errorMessage, string title, bool IsRTL = false)
+        {
+            try
+            {
+                using (var msg = new MessageBoxWindow())
+                {
+                    msg.Title = title;
+                    msg.TxtTitle.Text = title;
+                    msg.TxtMessage.Text = errorMessage;
+                    msg.TitleBackgroundPanel.Background = Brushes.Red;
+                    msg.BorderBrush = Brushes.Red;
+                    msg.BtnCancel.Visibility = Visibility.Collapsed;
+                    if (IsRTL)
+                    {
+                        msg.FlowDirection = FlowDirection.RightToLeft;
+                    }
+                    msg.BtnOk.Focus();
+                    msg.ShowDialog();
+                }
+            }
+            catch (Exception)
+            {
+                MessageBox.Show(errorMessage);
+            }
+        }
+
+        /// <summary>
         /// Displays a message box with a cancel button
         /// </summary>
         /// <param name="message">The message to display</param>

--- a/MaterialMessageBoxDemo/MainWindow.xaml
+++ b/MaterialMessageBoxDemo/MainWindow.xaml
@@ -22,6 +22,7 @@
             <Button Content="Show Error Message Message Box" Click="ShowErrorMessageBox_OnClick" Foreground="{DynamicResource MaterialDesignPaper}" HorizontalAlignment="Center" Margin="12"/>
             <Button Content="Show Custom Styled Message Box" Click="ShowCustomMessageBox_OnClick" HorizontalAlignment="Center" Foreground="{DynamicResource MaterialDesignPaper}" Margin="12"/>
             <Button Content="Show Message Box with Cancel Button" Click="ShowMessageBoxWithCancelButton_OnClick" Foreground="{DynamicResource MaterialDesignPaper}" HorizontalAlignment="Center" Margin="12"/>
+            <Button Content="Show Simple RTL Message Box" Click="ShowSimpleRTLMessageBox_OnClick" Foreground="{DynamicResource MaterialDesignPaper}" HorizontalAlignment="Center" Margin="12"/>
             <TextBlock Name="TxtResult" HorizontalAlignment="Center" Margin="12" Foreground="{DynamicResource IdealForegroundColorBrush}"/>
         </StackPanel>
     </Grid>

--- a/MaterialMessageBoxDemo/MainWindow.xaml.cs
+++ b/MaterialMessageBoxDemo/MainWindow.xaml.cs
@@ -61,5 +61,10 @@ namespace MaterialMessageBoxDemo
             var results = msg.Result;
             TxtResult.Text = $"Message Box Result is: {results}";
         }
+
+        private void ShowSimpleRTLMessageBox_OnClick(object sender, RoutedEventArgs e)
+        {
+            MaterialMessageBox.Show($"This is a simple message{Environment.NewLine}هذه رسالة بسيطة{Environment.NewLine}{Environment.NewLine}Is'nt it cool\n.\n.\nYou could even scroll!!!\nd\no\no\no\no\no\nw\nn", "Message Box Title", true);
+        }
     }
 }


### PR DESCRIPTION
Now we will be able to set the MessageBox FlowDirection to RightToLeft if we choose to
you can use it the old way for LTR
`MaterialMessageBox.Show("");`
or by adding true at the end for the RTL
`MaterialMessageBox.Show("", true);`
works for all cases

Also you can set a Title to ShowError MessageBox 

wishes for a new nuget package asap, thanks