### PR TITLE
Some additions and changes

### DIFF
--- a/BespokeFusion/MaterialMessageBox.cs
+++ b/BespokeFusion/MaterialMessageBox.cs
@@ -59,8 +59,8 @@ namespace BespokeFusion
             {
                 using (var msg = new MessageBoxWindow())
                 {
-                    msg.Title = MessageBoxTitle;
-                    msg.TxtTitle.Text = MessageBoxTitle;
+                    msg.Title = "Error";
+                    msg.TxtTitle.Text = "Error";
                     msg.TxtMessage.Text = errorMessage;
                     msg.TitleBackgroundPanel.Background = Brushes.Red;
                     msg.BorderBrush = Brushes.Red;
@@ -73,6 +73,89 @@ namespace BespokeFusion
             catch (Exception)
             {
                 MessageBox.Show(errorMessage);
+            }
+        }
+
+        /// <summary>
+        /// Displays an error message box
+        /// </summary>
+        /// <param name="errorMessage">The error error message to display</param>
+        /// <param name="errorTitle">The title of the error message box</param>
+        public static void ShowError(string errorMessage, string errorTitle)
+        {
+            try
+            {
+                using (var msg = new MessageBoxWindow())
+                {
+                    msg.Title = errorTitle;
+                    msg.TxtTitle.Text = errorTitle;
+                    msg.TxtMessage.Text = errorMessage;
+                    msg.TitleBackgroundPanel.Background = Brushes.Red;
+                    msg.BorderBrush = Brushes.Red;
+                    msg.BtnCancel.Visibility = Visibility.Collapsed;
+
+                    msg.BtnOk.Focus();
+                    msg.ShowDialog();
+                }
+            }
+            catch (Exception)
+            {
+                MessageBox.Show(errorMessage, errorTitle);
+            }
+        }
+
+        /// <summary>
+        /// Displays a warning message box
+        /// </summary>
+        /// <param name="warningMessage">The warning message to display</param>
+        public static void ShowWarning(string warningMessage)
+        {
+            try
+            {
+                using (var msg = new MessageBoxWindow())
+                {
+                    msg.Title = "Warning";
+                    msg.TxtTitle.Text = "Warning";
+                    msg.TxtMessage.Text = warningMessage;
+                    msg.TitleBackgroundPanel.Background = Brushes.Orange;
+                    msg.BorderBrush = Brushes.Orange;
+                    msg.BtnCancel.Visibility = Visibility.Collapsed;
+
+                    msg.BtnOk.Focus();
+                    msg.ShowDialog();
+                }
+            }
+            catch (Exception)
+            {
+                MessageBox.Show(warningMessage);
+            }
+        }
+
+        /// <summary>
+        /// Displays a warning message box
+        /// </summary>
+        /// <param name="warningMessage">The warning message to display</param>
+        /// <param name="warningTitle">The title of the error message box</param>
+        public static void ShowWarning(string warningMessage, string warningTitle)
+        {
+            try
+            {
+                using (var msg = new MessageBoxWindow())
+                {
+                    msg.Title = warningTitle;
+                    msg.TxtTitle.Text = warningTitle;
+                    msg.TxtMessage.Text = warningMessage;
+                    msg.TitleBackgroundPanel.Background = Brushes.Orange;
+                    msg.BorderBrush = Brushes.Orange;
+                    msg.BtnCancel.Visibility = Visibility.Collapsed;
+
+                    msg.BtnOk.Focus();
+                    msg.ShowDialog();
+                }
+            }
+            catch (Exception)
+            {
+                MessageBox.Show(warningMessage, warningTitle);
             }
         }
 


### PR DESCRIPTION
+ Added Warning Message Box 
Usage: ShowWarning(message) or ShowWarning(message, title)
* Now the ShowError can be ShowError(message) or ShowError(message, title).
* ShowError default title is now "Error" instead of "Message".

![wwt](https://user-images.githubusercontent.com/32852493/41814016-45c3bbb2-7718-11e8-989d-fbae29b25c68.png)

![wwt2](https://user-images.githubusercontent.com/32852493/41814017-48661d4c-7718-11e8-8600-bbd6a827a36b.png)

![ewt](https://user-images.githubusercontent.com/32852493/41814018-4b037004-7718-11e8-93ba-d2442f888bea.png)

![ewt2](https://user-images.githubusercontent.com/32852493/41814019-4d216648-7718-11e8-9119-2f055b3e7ac1.png)
